### PR TITLE
Service updates for Umbrel Compose v0.1.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
                 network_mode: host
                 stop_grace_period: 30s
         bitcoin:
-                image: lncm/bitcoind:v0.19.1
+                image: lncm/bitcoind:v0.20.0
                 logging: *default-logging
                 volumes:
                         - ${HOME}/bitcoin:/root/.bitcoin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,13 +51,17 @@ services:
                 restart: unless-stopped
                 network_mode: host
                 volumes:
-                        - "${HOME}/db:/db"
+                        - ${HOME}/db:/db
+                        - /var/run/docker.sock:/var/run/docker.sock
+                        - /usr/bin/docker:/usr/bin/docker
+                        - ${HOME}:${HOME}
                 environment:
                     PORT: "3006"
                     USER_PASSWORD_FILE: "/db/user.json"
                     JWT_PUBLIC_KEY_FILE: "/db/jwt-public-key/jwt.pem"
                     JWT_PRIVATE_KEY_FILE: "/db/jwt-private-key/jwt.key"
                     JWT_EXPIRATION: "3600"
+                    DOCKER_COMPOSE_DIRECTORY: $HOME
         middleware:
                 image: getumbrel/middleware:v0.1.0
                 command: ["./wait-for-node-manager.sh", "localhost", "npm", "start"]
@@ -66,8 +70,8 @@ services:
                 network_mode: host
                 depends_on: [ manager ]
                 volumes:
-                        - "${HOME}/lnd:/lnd"
-                        - "${HOME}/db/jwt-public-key:/jwt-public-key"
+                        - ${HOME}/lnd:/lnd
+                        - ${HOME}/db/jwt-public-key:/jwt-public-key
                 environment:
                     PORT: "3005"
                     BITCOIN_HOST: "0.0.0.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,12 +41,12 @@ services:
                 network_mode: host
                 stop_grace_period: 1m30s
         dashboard:
-                image: getumbrel/dashboard:v0.2.0
+                image: getumbrel/dashboard:master
                 logging: *default-logging
                 restart: always
                 network_mode: host
         manager:
-                image: getumbrel/manager:v0.1.0
+                image: getumbrel/manager:master
                 logging: *default-logging
                 restart: unless-stopped
                 network_mode: host
@@ -63,7 +63,7 @@ services:
                     JWT_EXPIRATION: "3600"
                     DOCKER_COMPOSE_DIRECTORY: $HOME
         middleware:
-                image: getumbrel/middleware:v0.1.0
+                image: getumbrel/middleware:master
                 command: ["./wait-for-node-manager.sh", "localhost", "npm", "start"]
                 logging: *default-logging
                 restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,12 +41,12 @@ services:
                 network_mode: host
                 stop_grace_period: 1m30s
         dashboard:
-                image: getumbrel/dashboard:master
+                image: getumbrel/dashboard:v0.2.1
                 logging: *default-logging
                 restart: always
                 network_mode: host
         manager:
-                image: getumbrel/manager:master
+                image: getumbrel/manager:v0.1.1
                 logging: *default-logging
                 restart: unless-stopped
                 network_mode: host
@@ -63,7 +63,7 @@ services:
                     JWT_EXPIRATION: "3600"
                     DOCKER_COMPOSE_DIRECTORY: $HOME
         middleware:
-                image: getumbrel/middleware:master
+                image: getumbrel/middleware:v0.1.1
                 command: ["./wait-for-node-manager.sh", "localhost", "npm", "start"]
                 logging: *default-logging
                 restart: unless-stopped


### PR DESCRIPTION
This PR updates the services in accordance with their next release. 

Will be merged after:
- [x] [Umbrel Dashboard](https://github.com/getumbrel/umbrel-dashboard) v0.2.1 is released 
- [x] [Umbrel Middleware](https://github.com/getumbrel/umbrel-middleware) v0.1.1 is released 
- [x] [Umbrel Manager](https://github.com/getumbrel/umbrel-manager) v0.1.1 is released

After which Umbrel Compose v0.1.1 will be ready for release.